### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/iamthebesthackerandcoder/bugeting-app/security/code-scanning/1](https://github.com/iamthebesthackerandcoder/bugeting-app/security/code-scanning/1)

The best way to fix this issue is to explicitly add a `permissions` block with the minimal required permissions, which in this case is `contents: read`.  
This should be added at either the root level (applies to all jobs) or to the specific `build` job (applies only to this job). Since there is only a single job shown and no reason to believe that other jobs would be added, adding at the job level is sufficient.

To implement the fix:
- Edit `.github/workflows/build-and-release.yml`
- Add the following block under the `build:` job declaration (line 11), **before** `runs-on:` (line 12):

```yaml
    permissions:
      contents: read
```

This restricts the `GITHUB_TOKEN` used in this job to read-only access to contents, minimizing the risk if secrets or tokens are leaked.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated CI build workflow to apply job-level permissions with read-only access to repository contents.
  * Pipeline configuration, build matrix, and commands remain unchanged; no impact to application features or UI.
  * This change affects internal release process only and should not alter builds, artifacts, or versioning outputs.
  * Applies only to the build job; other workflows and permissions are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->